### PR TITLE
Downgraded f4f nodes build 5 2

### DIFF
--- a/src/fog_log_flight.sh
+++ b/src/fog_log_flight.sh
@@ -30,10 +30,10 @@ start_service_logging mesh_pub.service
 start_service_logging mesh.service
 
 # F4F
-start_service_logging bumper.service
+# start_service_logging bumper.service
 start_service_logging control_interface.service
 start_service_logging navigation.service
-start_service_logging odometry2.service
+# start_service_logging odometry2.service
 start_service_logging octomap_server2.service
 start_service_logging mocap_pose.service
 start_service_logging rplidar.service

--- a/src/fog_log_flight.sh
+++ b/src/fog_log_flight.sh
@@ -5,7 +5,7 @@ source /opt/ros/galactic/setup_fog.sh
 LOG_FOLDER_NAME=flight_logs-$(date +%Y_%m_%d-%H%M%S)
 LOG_FOLDER_PATH=/home/sad/${LOG_FOLDER_NAME}
 LOG_PIDS=()
-NODES_PARAMS_TO_LOG=("bumper" "control_interface" "navigation")
+NODES_PARAMS_TO_LOG=("control_interface" "navigation")
 
 mkdir ${LOG_FOLDER_PATH}
 

--- a/src/fogsw_package_list.sh
+++ b/src/fogsw_package_list.sh
@@ -22,7 +22,7 @@
 #  ros-galactic-odometry2 \
   ros-galactic-octomap-server2 \
   ros-galactic-rplidar-ros2 \
-  rtl8812au-kmod \
+#  rtl8812au-kmod \
   px4-firmware-updater \
   wpasupplicant \
   linux-image-5.11.22-git20210928.2710467-fog \

--- a/src/fogsw_package_list.sh
+++ b/src/fogsw_package_list.sh
@@ -18,8 +18,8 @@
   ros-galactic-fog-msgs \
   ros-galactic-mocap-pose \
   ros-galactic-navigation \
-  ros-galactic-fog-bumper \
-  ros-galactic-odometry2 \
+#  ros-galactic-fog-bumper \
+#  ros-galactic-odometry2 \
   ros-galactic-octomap-server2 \
   ros-galactic-rplidar-ros2 \
   rtl8812au-kmod \


### PR DESCRIPTION
Bumper feature is disabled. Also, `rtl8812au-kmod` package is obsolete and disabled from checks.