### PR TITLE
Set default mavlink udp listen port 15761

### DIFF
--- a/src/download_px4_logfile.py
+++ b/src/download_px4_logfile.py
@@ -206,7 +206,7 @@ class LogFileDownloader:
     async def run(self):
         workdir = os.getcwd()
         parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,description=__doc__)
-        parser.add_argument('-a', '--address', action="store", help='Address to connect. (e.g serial:///dev/ttyACM0, udp:192.168.200.101:14540, tcp://:5760)', default='tcp://192.168.200.2:5760')
+        parser.add_argument('-a', '--address', action="store", help='Address to connect. (e.g serial:///dev/ttyACM0, udp:192.168.200.101:14540, tcp://:5760)', default='udp://:15761')
         parser.add_argument('-d', '--dir', action="store", help='Output directory (default .)', default=workdir)
         parser.add_argument('-l', '--latest', action="store_true", help='Fetch latest logfile and skip interactive selection')
         self.args = parser.parse_args()

--- a/src/flight_env_config.py
+++ b/src/flight_env_config.py
@@ -181,7 +181,7 @@ class FlightEnvChanger:
         parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,description=__doc__)
         parser.add_argument('COMMAND', choices=['check', 'download', 'upload', 'remove', 'reboot'], help='Command to execute',)
         parser.add_argument('-f', '--file', action="store", help='Path to local config file to be read/write', default='./config.txt')
-        parser.add_argument('-a', '--address', action="store", help='Address to connect. (e.g serial:///dev/ttyACM0, udp:192.168.200.101:14540, tcp://:5760)', default='tcp://:5760')
+        parser.add_argument('-a', '--address', action="store", help='Address to connect. (e.g serial:///dev/ttyACM0, udp://192.168.200.101:14540, tcp://:5760)', default='udp://:5760')
         self.args = parser.parse_args()
 
         await self.initialize()

--- a/src/mavlink_shell.py
+++ b/src/mavlink_shell.py
@@ -108,7 +108,7 @@ class MavlinkSerialPort():
 
 def main():
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument('port', metavar='PORT', nargs='?', default = None,
+    parser.add_argument('port', metavar='PORT', nargs='?', default = ':15761',
             help='Mavlink port name: serial: DEVICE[,BAUD], udp: IP:PORT, tcp: tcp:IP:PORT. Eg: \
 /dev/ttyUSB0 or 0.0.0.0:14550. Auto-detect serial if not given.')
     parser.add_argument("--baudrate", "-b", dest="baudrate", type=int,


### PR DESCRIPTION
By default fogsw_tools scripts shall use dedicated udp port (15761) added in mavlink-router for fogsw_tools usage. This way we can leave the mavlink-router default tcp service for external QGC use and make sure fogsw_tools use even external QGC is connected to drone.