### PR TITLE
Fix entrypoint and mission mavsdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,15 @@ RUN apt update \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
+ARG BUILDARCH
+ARG TARGETARCH
+
+# For qemu emulated arm64 builds, the pip3 install takes a lot of time.
+# This makes it so that at least for the native builds, we have the library.
+RUN if [ "$BUILDARCH" = "$TARGETARCH" ]; then \
+        pip3 install mavsdk; \
+    fi
+
 WORKDIR /fog-tools
 
 # make all commands in /fog-tools/* invocable without full path
@@ -27,3 +36,4 @@ COPY src/ /fog-tools/
 WORKDIR /tools-data
 
 CMD ["ls", "-1", "/fog-tools"]
+ENTRYPOINT [ "/bin/bash", "-c" ]

--- a/src/download_px4_logfile.py
+++ b/src/download_px4_logfile.py
@@ -1,8 +1,15 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 import asyncio
+import importlib.util
+import sys, os
+
+# For arm64, the docker image does not have mavsdk installed since qemu emulation is slow
+# Installing during runtime should be faster
+if importlib.util.find_spec('mavsdk') is None:
+    os.system('pip3 install mavsdk')
+
 from mavsdk import System
-import sys, os, re
 import argparse
 import tempfile
 import datetime

--- a/src/flight_env_config.py
+++ b/src/flight_env_config.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 """
 Flight Environment Config Changer
@@ -15,8 +15,16 @@ Command description:
 """
 
 import asyncio
+import importlib.util
+import sys, os
+
+# For arm64, the docker image does not have mavsdk installed since qemu emulation is slow
+# Installing during runtime should be faster
+if importlib.util.find_spec('mavsdk') is None:
+    os.system('pip3 install mavsdk')
+
 from mavsdk import System
-import sys, os, re
+import re
 import argparse
 import shutil
 


### PR DESCRIPTION
## Changelog:
-  Fix the entrypoint. Otherwise, it was giving errors as `/bin/ls: /bin/ls: cannot execute binary file` or `/fog-tools/mavlink_shell.py: line 13: from: command not found`
- Add pip3 install mavsdk when the TARGETARCH and BUILDARCH is the same. This means the GH runners will install the mavsdk python package when it is "amd64".
- And for the "arm64", the python script will check if the mavsdk could be imported. If not, then it is going to run the pip3 install command directly. The reason is that the arm64 qemu emulation is very slow for python commands, so adding a single pip3 install command could make the build on amd64 to take nearly an hour. Installing it during runtime should be much faster for arm64.