### PR TITLE
fix entrypoint more: fix run without args, fix multi-args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,24 @@ RUN if [ "$BUILDARCH" = "$TARGETARCH" ]; then \
         pip3 install mavsdk; \
     fi
 
-WORKDIR /fog-tools
-
 # make all commands in /fog-tools/* invocable without full path
 ENV PATH=$PATH:/fog-tools
 ENV PYTHONPATH=/usr/lib/python3.10/site-packages
 
 COPY src/ /fog-tools/
 
+# this dir is mounted to us by at least when running from fog-hyper's `$ fog tool` wrapper.
+# the point of it is to make it that if we write files (like recording a ROS bag or
+# downloading logs from Flight Controller), they end up in dir that is visible to debug web UI.
 WORKDIR /tools-data
 
-CMD ["ls", "-1", "/fog-tools"]
-ENTRYPOINT [ "/bin/bash", "-c" ]
+# this container shall have no `ENTRYPOINT` because the container is designed to be ran like:
+#   `$ docker run --rm -it fogsw-tools TOOL_NAME` and thus `/fog-tools/TOOL_NAME` will be invoked.
+# if we set ENTRYPOINT to ["bash", "-c"], the above command would then run something like `bash -c TOOL_NAME`. that would:
+# 1. work for single-argument commands (but we'd use shell unnecessarily)
+# 2. running `$ docker run .... fogsw-tools mavlink_shell.py --help` would exec `["bash", "-c", "mavlink_shell.py", "--help"]`
+#    i.e. the `--help` would go actually to Bash, so we'd lose multi-arg support and semantically it's borked.
+
+# intentionally no entrypoint but when container run without commands, list the tools available so
+# user knows to run the container again with the proper tool argument.
+CMD ["bash", "-c", "ls -1 /fog-tools"]


### PR DESCRIPTION
before this fix:

running without arguments listed the wrong directory because multi-args were not supported and we ended up running just `$ ls` instead of `$ ls -1 /fog-tools`

multi-args not processed:

```
$ docker run --rm -it ghcr.io/tiiuae/tii-fogsw-tools:sha-1064f1c mavlink_shell.py --help
Connecting to MAVLINK...
^CTraceback (most recent call last):
```

proof that --help is there:

```
$ docker run --rm -it --entrypoint=bash ghcr.io/tiiuae/tii-fogsw-tools:sha-1064f1c
$ mavlink_shell.py --help
usage: mavlink_shell.py [-h] [--baudrate BAUDRATE] [PORT]

Open a shell over MAVLink. @author: Beat Kueng (beat-kueng@gmx.net)
```