### PR TITLE
Fix entrypoint harder

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,12 +38,37 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build container image and push
+      - name: Build 🔨
         uses: docker/build-push-action@v5
         with:
-          context: .
+          outputs: type=docker
+          tags: smoketest-img  # proper tags will be pushed later
+
+      - name: Smoke test 🔥
+        run: |
+          set -eu
+
+          # when running without arguments, it should provide list of tools available
+          docker run --name=smoketest --rm -t smoketest-img > list-of-tools.txt
+
+          # ask for help with mavlink shell
+          docker run --name=smoketest --rm -t smoketest-img mavlink_shell.py --help > mavlink-shell-help.txt
+
+          if ! grep -q "mavlink_shell.py" list-of-tools.txt ; then
+              echo "when running without arguments it doesn't list the expected tool"
+              exit 1
+          fi
+
+          if ! grep -q "  --baudrate BAUDRATE" mavlink-shell-help.txt ; then
+              echo "Output of 'mavlink_shell.py --help' doesn't contain expected string"
+              exit 1
+          fi
+
+      - name: Push 🔼
+        uses: docker/build-push-action@v5
+        with:
           platforms: linux/amd64,linux/arm64,linux/riscv64
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,15 +25,27 @@ RUN if [ "$BUILDARCH" = "$TARGETARCH" ]; then \
         pip3 install mavsdk; \
     fi
 
-WORKDIR /fog-tools
-
 # make all commands in /fog-tools/* invocable without full path
 ENV PATH=$PATH:/fog-tools
 ENV PYTHONPATH=/usr/lib/python3.10/site-packages
 
 COPY src/ /fog-tools/
 
+# this dir is mounted to us by at least when running from fog-hyper's `$ fog tool` wrapper.
+# the point of it is to make it that if we write files (like recording a ROS bag or
+# downloading logs from Flight Controller), they end up in dir that is visible to debug web UI.
 WORKDIR /tools-data
 
-CMD ["ls", "-1", "/fog-tools"]
-ENTRYPOINT [ "/bin/bash", "-c" ]
+# explicitly remove possible entrypoint inherited from base image.
+#
+# this container shall have no `ENTRYPOINT` because the container is designed to be ran like:
+#   `$ docker run --rm -it fogsw-tools TOOL_NAME` and thus `/fog-tools/TOOL_NAME` will be invoked.
+# if we set ENTRYPOINT to ["bash", "-c"], the above command would then run something like `bash -c TOOL_NAME`. that would:
+# 1. work for single-argument commands (but we'd use shell unnecessarily)
+# 2. running `$ docker run .... fogsw-tools mavlink_shell.py --help` would exec `["bash", "-c", "mavlink_shell.py", "--help"]`
+#    i.e. the `--help` would go actually to Bash, so we'd lose multi-arg support and semantically it's borked.
+ENTRYPOINT []
+
+# intentionally no entrypoint but when container run without commands, list the tools available so
+# user knows to run the container again with the proper tool argument.
+CMD ["bash", "-c", "ls -1 /fog-tools"]


### PR DESCRIPTION
## Fix

The fix is outlined in commit description and code: https://github.com/tiiuae/fogsw_tools/pull/33/commits/e80e4ed8a663d630b24846c3bda655e7da2ce05c


## Smoke test

The smoke test will fail if there's regressions like this again. It will test these two assumptions:

- when container run without arguments, it lists the tools available
- when a command with two arguments is used, it works properly. also this tests:
    * that the container is able to run a tool
    * a specific tool `mavlink_shell.py` exists

I tested the smoke tests to fail if it doesn't find those specific strings from container output:

![image](https://github.com/tiiuae/fogsw_tools/assets/630151/7e3d876e-e95c-4959-beb0-1c88823711d3)

![image](https://github.com/tiiuae/fogsw_tools/assets/630151/4613d62f-ea29-4b41-982a-5e4c77d941d2)
