### PR TITLE
Add the argument for use_burst in mavsdk ftp plugin

### DIFF
--- a/src/download_px4_logfile.py
+++ b/src/download_px4_logfile.py
@@ -189,7 +189,7 @@ class LogFileDownloader:
 
     async def download_file(self, file, date, dir):
         previous_progress = 0
-        async for progress in self.mav.ftp.download(file, dir):
+        async for progress in self.mav.ftp.download(file, dir, False):
             new_progress = round((progress.bytes_transferred/progress.total_bytes)*100)
             if new_progress != previous_progress:
                 sys.stdout.write(f"\r{new_progress} %")

--- a/src/flight_env_config.py
+++ b/src/flight_env_config.py
@@ -143,7 +143,7 @@ class FlightEnvChanger:
         if await self.validate_config_file():
             if logging:
                 sys.stdout.write("Download")
-            progress = self.mav.ftp.download(self.config_file_path, '/tmp')
+            progress = self.mav.ftp.download(self.config_file_path, '/tmp', False)
             async for p in progress:
                 if logging:
                     sys.stdout.write(".")


### PR DESCRIPTION
## Changelog:
- Newer version of mavsdk python3 library needs an extra argument for `mavsdk.ftp.download` method called `use_burst: boolean`. Without it, it results with this error: 
```
 File "/fog-tools/download_px4_logfile.py", line 192, in download_file
 async for progress in self.mav.ftp.download(file, dir):
TypeError: Ftp.download() missing 1 required positional argument: 'use_burst'
```
Tested it via manually modifying the script on a drone and running it. It seem to be working OK after the change.