### PR TITLE
PKCS11 updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.1.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.2.0
 
 RUN apt update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
- upgrade base images v3.1.0 to v3.2.0
- remove obsolete PKCS11 related env vars
- upgrade msgs-nats if applicable
