### PR TITLE
Lock mavsdk version to 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ARG TARGETARCH
 # For qemu emulated arm64 builds, the pip3 install takes a lot of time.
 # This makes it so that at least for the native builds, we have the library.
 RUN if [ "$BUILDARCH" = "$TARGETARCH" ]; then \
-        pip3 install mavsdk; \
+        pip3 install mavsdk==2.1.0; \
     fi
 
 # make all commands in /fog-tools/* invocable without full path

--- a/src/download_px4_logfile.py
+++ b/src/download_px4_logfile.py
@@ -7,7 +7,7 @@ import sys, os
 # For arm64, the docker image does not have mavsdk installed since qemu emulation is slow
 # Installing during runtime should be faster
 if importlib.util.find_spec('mavsdk') is None:
-    os.system('pip3 install mavsdk')
+    os.system('pip3 install mavsdk==2.1.0')
 
 from mavsdk import System
 import argparse

--- a/src/flight_env_config.py
+++ b/src/flight_env_config.py
@@ -21,7 +21,7 @@ import sys, os
 # For arm64, the docker image does not have mavsdk installed since qemu emulation is slow
 # Installing during runtime should be faster
 if importlib.util.find_spec('mavsdk') is None:
-    os.system('pip3 install mavsdk')
+    os.system('pip3 install mavsdk==2.1.0')
 
 from mavsdk import System
 import re


### PR DESCRIPTION
Due to ABI changes via mavsdk-python 3.0.0, the ftp list_directory returns a different struct. Since for the arm64 and riscv64, the mavsdk is installed during the runtime, the version changes affects the functionality. The same is not observed with the amd64 build as the version has been locked during build time.