### PR TITLE
Bump tiiuae/fog-ros-baseimage from v3.3.0 to v3.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c04d413
+FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.4.0
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:v3.3.0
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-926c935
 
 RUN apt update \
     && apt install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-926c935
+FROM ghcr.io/tiiuae/fog-ros-baseimage:sha-c04d413
 
 RUN apt update \
     && apt install -y --no-install-recommends \


### PR DESCRIPTION
Update fog-ros-baseimage from sha-c04d413 to v3.4.0
This PR is auto generated by a remote workflow.
Message from author of this PR;
**PX4-MSGS Upgraded to v7.0.0**
